### PR TITLE
Graphite and Grafana

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,0 +1,7 @@
+FROM grafana/grafana:latest
+LABEL org.freenas.version=1                             \
+      org.freenas.web-ui-protocol="http"                \
+      org.freenas.expose-ports-at-host="true"           \
+      org.freenas.web-ui-port=3000                      \
+      org.freenas.port-mappings="3000:3000/tcp"
+      

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,2 @@
+A Grafana server. FreeNAS metadata added version of grafana/grafana. All vars in conf/grafana.ini can be overriden using environment variables.
+

--- a/graphite-statsd/Dockerfile
+++ b/graphite-statsd/Dockerfile
@@ -1,0 +1,33 @@
+FROM hopsoft/graphite-statsd:latest
+LABEL org.freenas.version=1                             \
+      org.freenas.web-ui-protocol="http"                \
+      org.freenas.expose-ports-at-host="true"           \
+      org.freenas.web-ui-port=5080                      \
+      org.freenas.port-mappings="80:5080/tcp,2003:2003/tcp,2004:2004/tcp,2023:2023/tcp,2024:2024/tcp,8125:8125/tcp,8126:8126/tcp"                                       \
+      org.freenas.volumes="[                            \
+          {                                             \
+              \"name\": \"/opt/graphite/conf\",         \
+              \"descr\": \"graphite config\"            \
+          },                                            \
+          {                                             \
+              \"name\": \"/opt/graphite/storage\",      \
+              \"descr\": \"graphite stats storage\"     \
+          },                                            \
+          {                                             \
+              \"name\": \"/etc/nginx\",                 \
+              \"descr\": \"nginx config\"               \
+          },                                            \
+          {                                             \
+              \"name\": \"/opt/statsd\",                \
+              \"descr\": \"statsd config\"              \
+          },                                            \
+          {                                             \
+              \"name\": \"/etc/logrotate.d\",           \
+              \"descr\": \"logrotate config\"           \
+          },                                            \
+          {                                             \
+              \"name\": \"/var/log\",                   \
+              \"descr\": \"log files\"                  \
+          }                                             \
+      ]"
+      

--- a/graphite-statsd/README.md
+++ b/graphite-statsd/README.md
@@ -1,1 +1,1 @@
-A Graphite server w/ statsd. FreeNAS metadata added version of hopsoft/graphite-statsd. Once it i running the FreeNAS System->Preferences->Remote Graphite Server option can be set to push data into it.
+A Graphite server w/ statsd. FreeNAS metadata added version of hopsoft/graphite-statsd. Once it is running the FreeNAS System->Preferences->Remote Graphite Server option can be set to push data into it.

--- a/graphite-statsd/README.md
+++ b/graphite-statsd/README.md
@@ -1,0 +1,1 @@
+A Graphite server w/ statsd. FreeNAS metadata added version of hopsoft/graphite-statsd. Once it i running the FreeNAS System->Preferences->Remote Graphite Server option can be set to push data into it.


### PR DESCRIPTION
The Graphite server will work as a FreeNAS Remote server.
The Grafana server also works with the Graphite server, at least enough to get a read/write bytes/sec of a zpool up and running.