### PR TITLE
Added Setup Instructions and Mappable Volumes

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,7 +1,20 @@
 FROM grafana/grafana:latest
-LABEL org.freenas.version=1                             \
+LABEL org.freenas.version=1.1                           \
       org.freenas.web-ui-protocol="http"                \
       org.freenas.expose-ports-at-host="true"           \
       org.freenas.web-ui-port=3000                      \
       org.freenas.port-mappings="3000:3000/tcp"
-      
+      org.freenas.volumes="[                            \
+          {                                             \
+              \"name\": \"/etc/grafana\",         \
+              \"descr\": \"grafana config\"            \
+          },                                            \
+          {                                             \
+              \"name\": \"/var/lib/grafana\",      \
+              \"descr\": \"grafana program storage\"     \
+          },                                            \
+          {                                             \
+              \"name\": \"/var/lib/grafana\",                 \
+              \"descr\": \"grafana logs\"               \
+          }
+       ]"

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,5 +1,5 @@
 FROM grafana/grafana:latest
-LABEL org.freenas.version=1.0                           \
+LABEL org.freenas.version=1                           \
       org.freenas.web-ui-protocol="http"                \
       org.freenas.expose-ports-at-host="true"           \
       org.freenas.web-ui-port=3000                      \

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,5 +1,5 @@
 FROM grafana/grafana:latest
-LABEL org.freenas.version=1.1                           \
+LABEL org.freenas.version=1.0                           \
       org.freenas.web-ui-protocol="http"                \
       org.freenas.expose-ports-at-host="true"           \
       org.freenas.web-ui-port=3000                      \

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,3 +1,23 @@
-[ NOTE:  This needs some REAL documentation!  This is just a place-holder ]
-
 A Grafana server (system statistics monitoring visualization toolkit). Base container is grafana/grafana with FreeNAS metadata added. All variables in conf/grafana.ini can be overriden using environment variables.
+
+How to setup Grafana to receive data from FreeNAS' Graphite sender
+
+1. Open up the WebUI and login with the username _admin_ and the password _admin_
+2. Once at the _Home_ dashboard click on the spiral in the upper left-hand corner and click _Data Sources_
+3. Select _Add Data Source_, then select a name for the data source, mark it as _Default_ if you would like; leave the type as _Graphite_; set the URL to the the IP of your Graphite Docker Container (which should already be setup to receive data from FreeNAS) and use port 80 if the container is bridged, otherwise use port 5080; leave everything under _HTTP Auth_ alone; click on the _Dashboards_ tab and select _import_ for _Graphite Carbon Metrics_; finally click _Add_ under the config tab
+
+Congratulations you have just setup Grafana to receive data from FreeNAS via the Graphite Docker Container! Now the real fun can begin.
+
+How to get Grafana to display the received data in pretty graphs
+
+1. You can click on either the spiral and select _Dashboards_ and click _New_ or click on the dashboard drop down menu (between the spiral and the gear) and select _Create New_ at the bottom. This will bring you to a new dashboard where you can create a customized dashboard to pretty much show whatever you want, and pretty much however you want. It's highly configurable!
+2. Let's create a graph for CPU temperature in degrees Celsius for one of our CPU cores, so select the _Graph_ panel, which will create a new graph, which will be empty.
+3. To fill it up with data click the word _Panel Title_ which will open up a small menu above the words, click _Edit_
+4. This will open up a edit menu. Under the _Metrics_ tab, in the row labeled _A_ click on _Select Metric_ and select _localhost_ (at least that's what mine says); click _Select Metric_ once again and select _cputemp-0_; Select _Temperature_ from the next field; Select _Value_ from the field after that
+5. Once the last value is set the graph auto-generates right before your eyes like magic! There's more customization to be done, unless you want to read your temperatures using the Kelvin scale
+6. Click on the _Axes_ tab and set _Scale_ under _Left Y_ to _Celsius_ under the _Temperature_ menu
+7. You can overlay more cores on to the same graph by clicking on the button with the three lines in row _A_, then selecting _Duplicate_, all you have to change is the second field (cputemp-N)
+8. Under the _General_ tab you can enter a name to describe this graph using the _Title_ field
+9. Once you're finished customizing the graph click the _X_ to close the _Edit_ panel, then click the _Save_ icon between the _Dashboard_ menu and the gear icon. Give the Panel a name, and click save. You can add more panels to the same dashboard using the same steps before or after saving the dashboard.
+
+Here is a instructional video from the creators of Graphana explaining this in visual form: https://www.youtube.com/watch?v=sKNZMtoSHN4

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,14 +1,14 @@
 A Grafana server (system statistics monitoring visualization toolkit). Base container is grafana/grafana with FreeNAS metadata added. All variables in conf/grafana.ini can be overriden using environment variables.
 
-How to setup Grafana to receive data from FreeNAS' Graphite sender
+### How to setup Grafana to receive data from FreeNAS' Graphite sender
 
-1. Open up the WebUI and login with the username _admin_ and the password _admin_
+1. Open up the WebUI and login with the username **admin** and the password **admin**
 2. Once at the _Home_ dashboard click on the spiral in the upper left-hand corner and click _Data Sources_
-3. Select _Add Data Source_, then select a name for the data source, mark it as _Default_ if you would like; leave the type as _Graphite_; set the URL to the the IP of your Graphite Docker Container (which should already be setup to receive data from FreeNAS) and use port 80 if the container is bridged, otherwise use port 5080; leave everything under _HTTP Auth_ alone; click on the _Dashboards_ tab and select _import_ for _Graphite Carbon Metrics_; finally click _Add_ under the config tab
+3. Select _Add Data Source_, then select a name for the data source, mark it as _Default_ if you would like; leave the type as _Graphite_; set the URL to the the IP of your Graphite Docker Container (which should already be setup to receive data from FreeNAS) and use **port 80** if the container is **bridged**, otherwise use **port 5080**; leave everything under _HTTP Auth_ alone; click on the _Dashboards_ tab and select _import_ for _Graphite Carbon Metrics_; finally click _Add_ under the config tab
 
 Congratulations you have just setup Grafana to receive data from FreeNAS via the Graphite Docker Container! Now the real fun can begin.
 
-How to get Grafana to display the received data in pretty graphs
+### How to get Grafana to display the received data in pretty graphs
 
 1. You can click on either the spiral and select _Dashboards_ and click _New_ or click on the dashboard drop down menu (between the spiral and the gear) and select _Create New_ at the bottom. This will bring you to a new dashboard where you can create a customized dashboard to pretty much show whatever you want, and pretty much however you want. It's highly configurable!
 2. Let's create a graph for CPU temperature in degrees Celsius for one of our CPU cores, so select the _Graph_ panel, which will create a new graph, which will be empty.
@@ -20,4 +20,8 @@ How to get Grafana to display the received data in pretty graphs
 8. Under the _General_ tab you can enter a name to describe this graph using the _Title_ field
 9. Once you're finished customizing the graph click the _X_ to close the _Edit_ panel, then click the _Save_ icon between the _Dashboard_ menu and the gear icon. Give the Panel a name, and click save. You can add more panels to the same dashboard using the same steps before or after saving the dashboard.
 
-Here is a instructional video from the creators of Graphana explaining this in visual form: https://www.youtube.com/watch?v=sKNZMtoSHN4
+Here is a instructional video from the creators of Graphana explaining this in visual form:
+
+<a href="http://www.youtube.com/watch?feature=player_embedded&v=sKNZMtoSHN4
+" target="_blank"><img src="http://img.youtube.com/vi/sKNZMtoSHN4/0.jpg" 
+alt="Creating a New Dashboard" width="240" height="180" border="10" /></a>

--- a/graphite-statsd/README.md
+++ b/graphite-statsd/README.md
@@ -1,4 +1,4 @@
-A Graphite server w/ statsd. Base container is hopsoft/graphite-statsd with FreeNAS metadata added. Once this container is running, the FreeNAS System->Preferences->Remote Graphite Server option can be set to push data into it.
+A Graphite server w/ statsd. Base container is hopsoft/graphite-statsd with FreeNAS metadata added. 
 
 ## Login instructions:
 
@@ -6,3 +6,13 @@ A Graphite server w/ statsd. Base container is hopsoft/graphite-statsd with Free
 Username: root
 Password: root
 ```
+### Setup Graphite to receive data from FreeNAS
+
+1. In FreeNAS go to _System_ -> _Preferences_ and scroll to the bottom and enter the IP of the Graphite server in the field labeled _Remote Graphite Server_ and click _Add_, then click _Save_
+2. Open up the Graphite Web UI and login with the username **root** and the password **root**
+3. In the tree in the left-hand pane, expand the _Metrics_ folder, then _localhost_ and you should see a bunch of folders under that, these are all statistics reported from FreeNAS
+4. If you click on a sub-folder, such as **cpu-0**, then **cpu-system**, then **value**, the chart in the center pane will populate with data. 
+   
+   _Note:_ You probably won't see anything if you have just recently created the Graphite-statd Docker container since data is collected over time and displayed in 4 hour spans.
+
+That's pretty much it for Graphite, it's pretty simple. If you would like pretty charts and tons of configurable metrics, use the Grafana Docker container in conjunction with Graphite.


### PR DESCRIPTION
Updated the readme.md with instructions on how setup Grafana to receive data from FreeNAS via the Graphite Docker container. Also updated the Dockerfile with mappable host to container directories.