### PR TITLE
Jackett Docker

### DIFF
--- a/jackett/Dockerfile
+++ b/jackett/Dockerfile
@@ -1,0 +1,37 @@
+FROM linuxserver/jackett:latest
+LABEL org.freenas.interactive="false"                                   \
+      org.freenas.version=1                                             \
+      org.freenas.upgradeable="true"                                    \
+      org.freenas.expose-ports-at-host="true"                           \
+      org.freenas.autostart="true"                                      \
+      org.freenas.web-ui-protocol="http"                                \
+      org.freenas.web-ui-port=9117                                      \
+      org.freenas.web-ui-path=""                                        \
+      org.freenas.port-mappings="9117:9117/tcp"                         \
+      org.freenas.volumes="[                                            \
+          {                                                             \
+              \"name\": \"/config\",                                    \
+              \"descr\": \"Config storage space\"                       \
+          },                                                            \
+          {                                                             \
+              \"name\": \"/downloads\",                                 \
+              \"descr\": \"Downloads volume\"                           \
+          }                                                             \
+      ]"                                                                \
+      org.freenas.settings="[                                           \
+          {                                                             \
+              \"env\": \"TZ\",                                          \
+              \"descr\": \"Timezone - eg Europe/London\",               \
+              \"optional\": true                                        \
+          }                                                             \
+          {                                                             \
+              \"env\": \"PGID\",                                        \
+              \"descr\": \"GroupID\",                                   \
+              \"optional\": true                                        \
+          },                                                            \
+          {                                                             \
+              \"env\": \"PUID\",                                        \
+              \"descr\": \"UserID\",                                    \
+              \"optional\": true                                        \
+         }                                                              \
+      ]"

--- a/jackett/README.md
+++ b/jackett/README.md
@@ -1,0 +1,5 @@
+Jackett Docker
+
+Jackett works as a proxy server: it translates queries from apps (Sonarr, SickRage, CouchPotato, Mylar, etc) into tracker-site-specific http queries, parses the html response, then sends results back to the requesting software. This allows for getting recent uploads (like RSS) and performing searches. Jackett is a single repository of maintained indexer scraping & translation logic - removing the burden from other apps.
+
+The web interface is at <your-ip>:9117 , configure various trackers and connections to other apps there.


### PR DESCRIPTION
Tested and working. Virtual networking prevents two docker containers talking to one another so they either both need to be bridged or have a common VLAN.