### PR TITLE
Radarr, Beets, ZNC, DuckDNS, LetsEncrypt and Davos Dockers

### DIFF
--- a/beets/Dockerfile
+++ b/beets/Dockerfile
@@ -19,7 +19,7 @@ LABEL org.freenas.interactive="false" 				\
           {						\
               \"name\": \"/downloads\",				\
               \"descr\": \"Downloads storage space\"	          \
-          },						\
+          }						\
       ]"							\
       org.freenas.settings="[ 				\
           {						\

--- a/beets/Dockerfile
+++ b/beets/Dockerfile
@@ -1,0 +1,35 @@
+FROM linuxserver/linuxserver/beets:latest
+LABEL org.freenas.interactive="false" 				\
+      org.freenas.version="0.1" 				\
+      org.freenas.upgradeable="true" 				\
+      org.freenas.expose-ports-at-host="true"			\
+      org.freenas.autostart="true" 				\
+      org.freenas.web-ui-port=8337                                    \
+      org.freenas.web-ui-path=""                                      \
+      org.freenas.port-mappings="8337:8337/tcp"                       \
+      org.freenas.volumes="[					\
+          {						\
+              \"name\": \"/config\",				\
+              \"descr\": \"Config storage space\"	                    \
+          },						\
+          {						\
+              \"name\": \"/music\",				\
+              \"descr\": \"Music storage space\"	                    \
+          },						\
+          {						\
+              \"name\": \"/downloads\",				\
+              \"descr\": \"Downloads storage space\"	          \
+          },						\
+      ]"							\
+      org.freenas.settings="[ 				\
+          {						\
+              \"env\": \"PGID\",				\
+              \"descr\": \"GroupID\",				\
+              \"optional\": true				\
+          },						\
+          {						\
+              \"env\": \"PUID\",				\
+              \"descr\": \"UserID\",				\
+              \"optional\": true				\
+         }						\
+      ]"

--- a/beets/README.md
+++ b/beets/README.md
@@ -1,0 +1,1 @@
+Beets is a music library manager and not, for the most part, a music player. It does include a simple player plugin and an experimental Web-based player, but it generally leaves actual sound-reproduction to specialized tools.

--- a/davos/Dockerfile
+++ b/davos/Dockerfile
@@ -1,0 +1,32 @@
+FROM linuxserver/daveos:latest
+LABEL org.freenas.interactive="false" 				\
+      org.freenas.version="0.1" 				\
+      org.freenas.upgradeable="true" 				\
+      org.freenas.expose-ports-at-host="true"			\
+      org.freenas.autostart="true" 				\
+      org.freenas.web-ui-protocol="http" 			\
+      org.freenas.web-ui-port=34567 				\
+      org.freenas.web-ui-path="" 				\
+      org.freenas.port-mappings="34567:8080/tcp" 			\
+      org.freenas.volumes="[					\
+          {						\
+              \"name\": \"/config\",				\
+              \"descr\": \"Config and database storage space\"	\
+          },						\
+          {						\
+              \"name\": \"/downloads\",				\
+              \"descr\": \"Location of downloads\"		\
+          }						\
+      ]"							\
+      org.freenas.settings="[ 				\
+          {						\
+              \"env\": \"PGID\",				\
+              \"descr\": \"GroupID\",				\
+              \"optional\": true				\
+          },						\
+          {						\
+              \"env\": \"PUID\",				\
+              \"descr\": \"UserID\",				\
+              \"optional\": true				\
+         }						\
+      ]"

--- a/davos/Dockerfile
+++ b/davos/Dockerfile
@@ -1,13 +1,9 @@
 FROM linuxserver/daveos:latest
 LABEL org.freenas.interactive="false" 				\
       org.freenas.version="0.1" 				\
-      org.freenas.upgradeable="true" 				\
-      org.freenas.expose-ports-at-host="true"			\
       org.freenas.autostart="true" 				\
-      org.freenas.web-ui-protocol="http" 			\
-      org.freenas.web-ui-port=34567 				\
-      org.freenas.web-ui-path="" 				\
-      org.freenas.port-mappings="34567:8080/tcp" 			\
+      org.freenas.bridged="true" 				\
+      org.freenas.dhcp="true" 				\
       org.freenas.volumes="[					\
           {						\
               \"name\": \"/config\",				\

--- a/davos/README.md
+++ b/davos/README.md
@@ -1,0 +1,13 @@
+DaveOS is an FTP automation tool that periodically scans given host locations for new files. It can be configured for various purposes, including listening for specific files to appear in the host location, ready for it to download and then move, if required. It also supports completion notifications as well as downstream API calls, to further the workflow.
+
+docker create \
+  --name=davos \
+  -v <path to data>:/config \
+  -v <path to downloads folder>:/download
+  -e PGID=<gid> -e PUID=<uid>  \
+  -p 8080:8080 \
+  linuxserver/davos
+
+The application does not require any set up other than starting the docker container. Further documentation can be found on the davos GitHub repository page.
+
+Common WebUI port remapped from 8080 to 34567.

--- a/duckdns/Dockerfile
+++ b/duckdns/Dockerfile
@@ -1,0 +1,37 @@
+FROM linuxserver/duckdns:latest
+LABEL org.freenas.interactive="false"			\
+      org.freenas.version="0.1" 			\
+      org.freenas.upgradeable="true" 			\
+      org.freenas.expose-ports-at-host="true" 		\
+      org.freenas.autostart="true" 			\
+      org.freenas.bridged="false" 			\
+      org.freenas.web-ui-port=23456 			\
+      org.freenas.web-ui-path="" 			\
+      org.freenas.port-mappings="23456:80/tcp" 		\
+      org.freenas.settings="[ 			\
+          {					\
+              \"env\": \"SUBDOMAINS\",			\
+              \"descr\": \"DuckDNS Subdomains\",		\
+              \"optional\": false			\
+          },					\
+          {					\
+              \"env\": \"TOKEN\",			\
+              \"descr\": \"DuckDNS Token\",		\
+              \"optional\": false			\
+          }, 					\					\
+          {					\
+              \"env\": \"TZ\",			\
+              \"descr\": \"Timezone - eg Europe/London\",	\
+              \"optional\": true			\
+          },					\
+          {					\
+              \"env\": \"PGID\",			\
+              \"descr\": \"GroupID\",			\
+              \"optional\": true			\
+          },					\
+          {					\
+              \"env\": \"PUID\",			\
+              \"descr\": \"UserID\",			\
+              \"optional\": true			\
+         }					\
+      ]"

--- a/duckdns/Dockerfile
+++ b/duckdns/Dockerfile
@@ -18,7 +18,7 @@ LABEL org.freenas.interactive="false"			\
               \"env\": \"TOKEN\",			\
               \"descr\": \"DuckDNS Token\",		\
               \"optional\": false			\
-          }, 					\					\
+          }, 					\
           {					\
               \"env\": \"TZ\",			\
               \"descr\": \"Timezone - eg Europe/London\",	\

--- a/duckdns/README.md
+++ b/duckdns/README.md
@@ -1,0 +1,13 @@
+Duck DNS is a free service which will point a DNS (sub domains of duckdns.org) to an IP of your choice. The service is completely free, and doesn't require reactivation or forum posts to maintain its existence.
+
+Setting up the application
+
+First, go to duckdns site, register your subdomain and retrieve your token
+Then run the docker create command above with your subdomain(s) and token
+It will update your IP with the DuckDNS service every 5 minutes
+
+-e PGID for GroupID - see below for explanation
+-e PUID for UserID - see below for explanation
+-e SUBDOMAINS for subdomains - multiple subdomains allowed, comma separated, no spaces
+-e TOKEN for DuckDNS token
+-e TZ for timezone information, eg Europe/London

--- a/jackett/Dockerfile
+++ b/jackett/Dockerfile
@@ -23,7 +23,7 @@ LABEL org.freenas.interactive="false"                                   \
               \"env\": \"TZ\",                                          \
               \"descr\": \"Timezone - eg Europe/London\",               \
               \"optional\": true                                        \
-          }                                                             \
+          },                                                            \
           {                                                             \
               \"env\": \"PGID\",                                        \
               \"descr\": \"GroupID\",                                   \

--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -1,0 +1,58 @@
+FROM linuxserver/letsencrypt:latest
+LABEL org.freenas.interactive="false" 				\
+      org.freenas.version="1" 				\
+      org.freenas.upgradeable="true" 				\
+      org.freenas.expose-ports-at-host="true"			\
+      org.freenas.autostart="true" 				\
+      org.freenas.bridged="true" 				\
+      org.freenas.dhcp="true" 				\
+      org.freenas.privileged="true"				\
+      org.freenas.port-mappings="443:443/tcp" 			\
+      org.freenas.volumes="[					\
+          {						\
+              \"name\": \"/config\",				\
+              \"descr\": \"Config storage space\"			\
+          },						\
+      ]"							\
+      org.freenas.settings="[ 				\
+          {						\
+              \"env\": \"EMAIL\",				\
+              \"descr\": \"your email for cert registration\",	\
+              \"optional\": false				\
+          },						\
+          {						\
+              \"env\": \"DHLEVEL\",				\
+              \"descr\": \"dhparams bit value - default=2048, can be set to 1024 or 4096\", \
+              \"optional\": true				\
+          },						\
+          {						\
+              \"env\": \"URL\",				\
+              \"descr\": \"the top url you have control over customdomain.com if you own it, or customsubdomain.ddnsprovider.com if dynamic dns)\",	\
+              \"optional\": false				\
+         },						\
+          {						\
+              \"env\": \"SUBDOMAINS\",				\
+              \"descr\": \"subdomains you'd like the cert to cover (comma separated, no spaces) ie. www,ftp,cloud\",				\
+              \"optional\": true				\
+          },						\
+          {						\
+              \"env\": \"ONLY_SUBDOMAINS\",			\
+              \"descr\": \"if you wish to get certs only for certain subdomains, but not the main domain (main domain may be hosted on another machine and cannot be validated), set this to true\",				\
+              \"optional\": true				\
+          },						\
+          {						\
+              \"env\": \"TZ\",				\
+              \"descr\": \"timezone ie. America/New_York\",		\
+              \"optional\": true				\
+         },						\
+          {						\
+              \"env\": \"PGID\",				\
+              \"descr\": \"GroupID\",				\
+              \"optional\": true				\
+          },						\
+          {						\
+              \"env\": \"PUID\",				\
+              \"descr\": \"UserID\",				\
+              \"optional\": true				\
+         }						\
+      ]"

--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -1,18 +1,15 @@
 FROM linuxserver/letsencrypt:latest
 LABEL org.freenas.interactive="false" 				\
       org.freenas.version="1" 				\
-      org.freenas.upgradeable="true" 				\
-      org.freenas.expose-ports-at-host="true"			\
       org.freenas.autostart="true" 				\
       org.freenas.bridged="true" 				\
       org.freenas.dhcp="true" 				\
       org.freenas.privileged="true"				\
-      org.freenas.port-mappings="443:443/tcp" 			\
       org.freenas.volumes="[					\
           {						\
               \"name\": \"/config\",				\
               \"descr\": \"Config storage space\"			\
-          },						\
+          }						\
       ]"							\
       org.freenas.settings="[ 				\
           {						\
@@ -29,7 +26,7 @@ LABEL org.freenas.interactive="false" 				\
               \"env\": \"URL\",				\
               \"descr\": \"the top url you have control over customdomain.com if you own it, or customsubdomain.ddnsprovider.com if dynamic dns)\",	\
               \"optional\": false				\
-         },						\
+          },						\
           {						\
               \"env\": \"SUBDOMAINS\",				\
               \"descr\": \"subdomains you'd like the cert to cover (comma separated, no spaces) ie. www,ftp,cloud\",				\

--- a/letsencrypt/README.md
+++ b/letsencrypt/README.md
@@ -1,0 +1,11 @@
+This container sets up an Nginx webserver and reverse proxy with php support and a built-in letsencrypt client that automates free SSL server certificate generation and renewal processes. It also contains fail2ban for intrusion prevention.
+
+Before running this container, make sure that the url and subdomains are properly forwarded to this container's host.
+
+Port 443 on the internet side of the router should be forwarded to this container's port 443.
+
+If you need a dynamic dns provider, you can use the free provider duckdns.org where the url will be yoursubdomain.duckdns.org and the subdomains can be www,ftp,cloud
+
+The container detects changes to url and subdomains, revokes existing certs and generates new ones during start. It also detects changes to the DHLEVEL parameter and replaces the dhparams file.
+
+If you'd like to password protect your sites, you can use htpasswd. Run the following command on your host to generate the htpasswd file "letsencrypt htpasswd -c /config/nginx/.htpasswd <username>"

--- a/radarr/Dockerfile
+++ b/radarr/Dockerfile
@@ -27,7 +27,7 @@ LABEL org.freenas.interactive="false"                                   \
               \"env\": \"TZ\",                                          \
               \"descr\": \"Timezone - eg Europe/London\",               \
               \"optional\": true                                        \
-          },                                                             \
+          },                                                            \
           {                                                             \
               \"env\": \"PGID\",                                        \
               \"descr\": \"GroupID\",                                   \

--- a/radarr/Dockerfile
+++ b/radarr/Dockerfile
@@ -16,7 +16,7 @@ LABEL org.freenas.interactive="false"                                   \
           {                                                             \
               \"name\": \"/downloads\",                                 \
               \"descr\": \"Downloads volume\"                           \
-          }                                                             \
+          },                                                            \
           {                                                             \
               \"name\": \"/movies\",                                    \
               \"descr\": \"Movies volume\"                              \
@@ -27,7 +27,7 @@ LABEL org.freenas.interactive="false"                                   \
               \"env\": \"TZ\",                                          \
               \"descr\": \"Timezone - eg Europe/London\",               \
               \"optional\": true                                        \
-          }                                                             \
+          },                                                             \
           {                                                             \
               \"env\": \"PGID\",                                        \
               \"descr\": \"GroupID\",                                   \

--- a/radarr/Dockerfile
+++ b/radarr/Dockerfile
@@ -1,0 +1,41 @@
+FROM linuxserver/radarr:latest
+LABEL org.freenas.interactive="false"                                   \
+      org.freenas.version=1                                             \
+      org.freenas.upgradeable="true"                                    \
+      org.freenas.expose-ports-at-host="true"                           \
+      org.freenas.autostart="true"                                      \
+      org.freenas.web-ui-protocol="http"                                \
+      org.freenas.web-ui-port=7878                                      \
+      org.freenas.web-ui-path=""                                        \
+      org.freenas.port-mappings="7878:7878/tcp"                         \
+      org.freenas.volumes="[                                            \
+          {                                                             \
+              \"name\": \"/config\",                                    \
+              \"descr\": \"Config storage space\"                       \
+          },                                                            \
+          {                                                             \
+              \"name\": \"/downloads\",                                 \
+              \"descr\": \"Downloads volume\"                           \
+          }                                                             \
+          {                                                             \
+              \"name\": \"/movies\",                                    \
+              \"descr\": \"Movies volume\"                              \
+          }                                                             \
+      ]"                                                                \
+      org.freenas.settings="[                                           \
+          {                                                             \
+              \"env\": \"TZ\",                                          \
+              \"descr\": \"Timezone - eg Europe/London\",               \
+              \"optional\": true                                        \
+          }                                                             \
+          {                                                             \
+              \"env\": \"PGID\",                                        \
+              \"descr\": \"GroupID\",                                   \
+              \"optional\": true                                        \
+          },                                                            \
+          {                                                             \
+              \"env\": \"PUID\",                                        \
+              \"descr\": \"UserID\",                                    \
+              \"optional\": true                                        \
+         }                                                              \
+      ]"

--- a/radarr/README.md
+++ b/radarr/README.md
@@ -1,0 +1,3 @@
+Radarr - A fork of Sonarr to work with movies Ã la Couchpotato. 
+
+Access the webui at <your-ip>:7878

--- a/transmission/Dockerfile
+++ b/transmission/Dockerfile
@@ -1,41 +1,41 @@
 FROM linuxserver/transmission:latest
-LABEL org.freenas.interactive="false" \
-      org.freenas.version=1 \
-      org.freenas.upgradeable="true" \
-      org.freenas.expose-ports-at-host="true" \
-      org.freenas.autostart="true" \
-      org.freenas.web-ui-protocol="http" \
-      org.freenas.web-ui-port=9091 \
-      org.freenas.web-ui-path="" \
+LABEL org.freenas.interactive="false" 					\
+      org.freenas.version=1 						\
+      org.freenas.upgradeable="true" 					\
+      org.freenas.expose-ports-at-host="true" 				\
+      org.freenas.autostart="true" 					\
+      org.freenas.web-ui-protocol="http" 				\
+      org.freenas.web-ui-port=9091 					\
+      org.freenas.web-ui-path="" 					\
       org.freenas.port-mappings="9091:9091/tcp,51413:51413/tcp,51413:51413/udp" \
       org.freenas.volumes="[						\
-          {								\
+          {							\
               \"name\": \"/config\",					\
-              \"descr\": \"Config storage space\"			\
-          },								\
-          {								\
+              \"descr\": \"Config storage space\"				\
+          },							\
+          {							\
               \"name\": \"/watch\",					\
-              \"descr\": \"Watch folder for torrent files\"		\
-          },								\
-          {								\
+              \"descr\": \"Watch folder for torrent files\"			\
+          },							\
+          {							\
               \"name\": \"/downloads\",					\
               \"descr\": \"Downloads volume\"				\
-          }								\
-      ]" \
-      org.freenas.settings="[ 						\
-          {								\
-              \"env\": \"TZ\",						\
-              \"descr\": \"Timezone - eg Europe/London\",		\
+          }							\
+      ]" 								\
+      org.freenas.settings="[ 					\
+          {							\
+              \"env\": \"TZ\",					\
+              \"descr\": \"Timezone - eg Europe/London\",			\
               \"optional\": true					\
-          }								\
-          {								\
+          },							\
+          {							\
               \"env\": \"PGID\",					\
-              \"descr\": \"GroupID\",				\
+              \"descr\": \"GroupID\",					\
               \"optional\": true					\
-          },								\
-          {								\
+          },							\
+          {							\
               \"env\": \"PUID\",					\
-              \"descr\": \"UserID\",				\
+              \"descr\": \"UserID\",					\
               \"optional\": true					\
-         }								\
+         }							\
       ]"

--- a/znc/Dockerfile
+++ b/znc/Dockerfile
@@ -1,0 +1,30 @@
+FROM linuxserver/znc:latest
+LABEL org.freenas.interactive="false"			\
+      org.freenas.version=1 				\
+      org.freenas.upgradeable="true" 			\
+      org.freenas.expose-ports-at-host="true" 		\
+      org.freenas.autostart="true" 			\
+      org.freenas.port-mappings="6501:6501/tcp" 		\
+      org.freenas.volumes="[				\
+          {					\
+              \"name\": \"/config\",			\
+              \"descr\": \"Config storage space\"		\
+          }					\								\
+      ]" 						\
+      org.freenas.settings="[ 			\
+          {					\
+              \"env\": \"TZ\",			\
+              \"descr\": \"Timezone - eg Europe/London\",	\
+              \"optional\": true			\
+          },					\
+          {					\
+              \"env\": \"PGID\",			\
+              \"descr\": \"GroupID\",			\
+              \"optional\": true			\
+          },					\
+          {					\
+              \"env\": \"PUID\",			\
+              \"descr\": \"UserID\",			\
+              \"optional\": true			\
+         }					\
+      ]"

--- a/znc/README.md
+++ b/znc/README.md
@@ -1,0 +1,3 @@
+ZNC is an IRC network bouncer or BNC. It can detach the client from the actual IRC server, and also from selected channels. Multiple clients from different locations can connect to a single ZNC account simultaneously and therefore appear under the same nickname on IRC.
+
+ZNC port is 6501.


### PR DESCRIPTION
Adds working Radarr, Beets, ZNC, DuckDNS, LetsEncrypt and Davos Dockers.

Also makes minor fixes to transmission (missing comma) and jackett (missing comma).