### PR TITLE
Fix volume path templates

### DIFF
--- a/jdownloader/Dockerfile
+++ b/jdownloader/Dockerfile
@@ -6,11 +6,11 @@ LABEL org.freenas.interactive="false"				\
       org.freenas.autostart="true"				\
       org.freenas.volumes="[					\
           {							\
-              \"name\": \"jdownloader/cfg\",			\
+              \"name\": \"/jdownloader/cfg\",			\
               \"descr\": \"Configuration files directory\"	\
           },							\
           {							\
-              \"name\": \"jdownloader/downloads\",		\
+              \"name\": \"/jdownloader/downloads\",		\
               \"descr\": \"downloads Folder\"			\
           },							\
           {							\


### PR DESCRIPTION
The two "jdownloader" volume definitions in the metadata are *relative* (`jdownloader/cfg` and `jdownloader/download` instead of *`/jdownloader/cfg`* and *`/jdownloader/downloads`*). 

When creating a new Docker Container from this Template, the process fails with the following error message:

`Task #556 error: 500 Server Error: Internal Server Error ("b'{"message":"Invalid volume spec \\"jdownloader/downloads\\": Invalid volume destination path: \'jdownloader/downloads\' mount path must be absolute."}'")`