### PR TITLE
Added Pi-Hole

### DIFF
--- a/pi-hole/Dockerfile
+++ b/pi-hole/Dockerfile
@@ -1,0 +1,49 @@
+FROM diginc/pi-hole:alpine
+LABEL org.freenas.interactive="false"                           \
+      org.freenas.version="1"                              \
+      org.freenas.upgradeable="false"                           \
+      org.freenas.expose-ports-at-host="true"                   \
+      org.freenas.autostart="true"                              \
+      org.freenas.capabilities-add="NET_ADMIN"                  \
+      org.freenas.web-ui-protocol="http"                        \
+      org.freenas.web-ui-port=80                                \
+      org.freenas.web-ui-path="admin"                           \
+      org.freenas.port-mappings="53:53/tcp,53:53/udp,80:80/tcp" \
+      org.freenas.volumes="[                         \
+          {                                          \
+              \"name\": \"/etc/pihole/\",            \
+              \"descr\": \"Configuration directory\" \
+          }                                          \
+      ]"                                             \
+      org.freenas.settings="[                                                            \
+          {                                                                              \
+              \"env\": \"ServerIP\",                                                     \
+              \"descr\": \"This container's external IP\",                               \
+              \"optional\": false                                                        \
+          },                                                                             \
+          {                                                                              \
+              \"env\": \"WEBPASSWORD\",                                                  \
+              \"descr\": \"Custom password; set this or Pi-Hole generates one for you\", \
+              \"optional\": true                                                         \
+          },                                                                             \
+          {                                                                              \
+              \"env\": \"DNS1\",                                                         \
+              \"descr\": \"Primary upstream DNS; default: 8.8.8.8\",                     \
+              \"optional\": true                                                         \
+          },                                                                             \
+          {                                                                              \
+              \"env\": \"DNS2\",                                                         \
+              \"descr\": \"Secondary upstream DNS; default: 8.8.4.4\",                   \
+              \"optional\": true                                                         \
+          },                                                                             \
+          {                                                                              \
+              \"env\": \"VIRTUAL_HOST\",                                                 \
+              \"descr\": \"Allows admin-access using a custom hostname / IP\",           \
+              \"optional\": true                                                         \
+          },                                                                             \
+          {                                                                              \
+              \"env\": \"IPv6\",                                                         \
+              \"descr\": \"Set to 'false' to disable IPv6 support\",                     \
+              \"optional\": true                                                         \
+          }                                                                              \
+      ]"

--- a/pi-hole/README.md
+++ b/pi-hole/README.md
@@ -1,0 +1,13 @@
+# Pi-Hole
+A black hole for Internet advertisements, based on the Docker image of [Diginc](https://github.com/diginc/docker-pi-hole).
+
+## About Pi-Hole
+Pi-Hole block ads for all your devices on DNS-level without the need to install client-side software.
+
+### More
+* [Website](https://pi-hole.net)
+* [GitHub](https://github.com/pi-hole/pi-hole)
+
+## About this image
+This Docker image is based on the image of [Diginc](https://github.com/diginc/docker-pi-hole).  
+The project's [README.md](https://github.com/diginc/docker-pi-hole/blob/master/README.md) contains an overview of the available [environment variables](https://github.com/diginc/docker-pi-hole/blob/master/README.md#environment-variables) and [volume mounts](https://github.com/diginc/docker-pi-hole/blob/master/README.md#volume-mounts).


### PR DESCRIPTION
I added a Dockerfile for Pi-Hole, which is basically "a black hole for Internet advertisements" by blocking ads on the DNS-level.
You can read about it [on their Website](https://pi-hole.net) and their [GitHub repository](https://github.com/pi-hole/pi-hole).

As there is no official Docker image I used [this project](https://github.com/diginc/docker-pi-hole) as a basis.

If you want to test the image have a look at [this](https://hub.docker.com/r/marvinmenzerath/pi-hole/) automated build on Docker Hub.