### PR TITLE
Apache WordPress Container

### DIFF
--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -1,0 +1,34 @@
+FROM library/wordpress:4-php7.1-apache
+LABEL org.freenas.interactive="false" 				\
+      org.freenas.version="1.0.1"				\
+      org.freenas.upgradeable="true" 				\
+      org.freenas.expose-ports-at-host="true" 			\
+      org.freenas.autostart="true" 				\
+      org.freenas.port-mappings="80:80/tcp,443:443/tcp" 	\
+      org.freenas.settings="[					\
+          {							\
+              \"env\": \"WORDPRESS_DB_HOST\",			\
+              \"descr\": \"SQL DB IP Address\",			\
+              \"optional\": false				\
+	  },							\
+          {							\
+              \"env\": \"WORDPRESS_DB_USER\",			\
+              \"descr\": \"SQL DB Username\",			\
+              \"optional\": false				\
+	  },							\
+          {							\
+              \"env\": \"WORDPRESS_DB_PASSWORD\",		\
+              \"descr\": \"SQL DB Password\",			\
+              \"optional\": false				\
+	  },							\
+          {							\
+              \"env\": \"WORDPRESS_DB_NAME\",			\
+              \"descr\": \"SQL DB Name\",			\
+              \"optional\": true				\
+	  },							\
+          {							\
+              \"env\": \"WORDPRESS_TABLE_PREFIX\",		\
+              \"descr\": \"SQL Table Prefix\",			\
+              \"optional\": true				\
+	  }							\
+      ]" 

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -3,16 +3,16 @@
 
 The following environment variables are also honored for configuring your WordPress instance:
 
--e WORDPRESS_DB_HOST=... (defaults to the IP and port of the linked mysql container)
+WORDPRESS_DB_HOST=... (defaults to the IP and port of the linked mysql container)
 
--e WORDPRESS_DB_USER=... (defaults to "root")
+WORDPRESS_DB_USER=... (defaults to "root")
 
--e WORDPRESS_DB_PASSWORD=... (defaults to the value of the MYSQL_ROOT_PASSWORD environment variable from the linked mysql container)
+WORDPRESS_DB_PASSWORD=... (defaults to the value of the MYSQL_ROOT_PASSWORD environment variable from the linked mysql container)
 
--e WORDPRESS_DB_NAME=... (defaults to "wordpress")
+WORDPRESS_DB_NAME=... (defaults to "wordpress")
 
--e WORDPRESS_TABLE_PREFIX=... (defaults to "", only set this when you need to override the default table prefix in wp-config.php)
+WORDPRESS_TABLE_PREFIX=... (defaults to "", only set this when you need to override the default table prefix in wp-config.php)
 
--e WORDPRESS_AUTH_KEY=..., -e WORDPRESS_SECURE_AUTH_KEY=..., -e WORDPRESS_LOGGED_IN_KEY=..., -e WORDPRESS_NONCE_KEY=..., -e WORDPRESS_AUTH_SALT=..., -e WORDPRESS_SECURE_AUTH_SALT=..., -e WORDPRESS_LOGGED_IN_SALT=..., -e WORDPRESS_NONCE_SALT=... (default to unique random SHA1s)
+WORDPRESS_AUTH_KEY=..., -e WORDPRESS_SECURE_AUTH_KEY=..., -e WORDPRESS_LOGGED_IN_KEY=..., -e WORDPRESS_NONCE_KEY=..., -e WORDPRESS_AUTH_SALT=..., -e WORDPRESS_SECURE_AUTH_SALT=..., -e WORDPRESS_LOGGED_IN_SALT=..., -e WORDPRESS_NONCE_SALT=... (default to unique random SHA1s)
 
 If the WORDPRESS_DB_NAME specified does not already exist on the given MySQL server, it will be created automatically upon startup of the wordpress container, provided that the WORDPRESS_DB_USER specified has the necessary permissions to create it.

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -14,4 +14,5 @@ The following environment variables are also honored for configuring your WordPr
 -e WORDPRESS_TABLE_PREFIX=... (defaults to "", only set this when you need to override the default table prefix in wp-config.php)
 
 -e WORDPRESS_AUTH_KEY=..., -e WORDPRESS_SECURE_AUTH_KEY=..., -e WORDPRESS_LOGGED_IN_KEY=..., -e WORDPRESS_NONCE_KEY=..., -e WORDPRESS_AUTH_SALT=..., -e WORDPRESS_SECURE_AUTH_SALT=..., -e WORDPRESS_LOGGED_IN_SALT=..., -e WORDPRESS_NONCE_SALT=... (default to unique random SHA1s)
+
 If the WORDPRESS_DB_NAME specified does not already exist on the given MySQL server, it will be created automatically upon startup of the wordpress container, provided that the WORDPRESS_DB_USER specified has the necessary permissions to create it.

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -1,0 +1,12 @@
+
+## How to use this image
+
+The following environment variables are also honored for configuring your WordPress instance:
+
+-e WORDPRESS_DB_HOST=... (defaults to the IP and port of the linked mysql container)
+-e WORDPRESS_DB_USER=... (defaults to "root")
+-e WORDPRESS_DB_PASSWORD=... (defaults to the value of the MYSQL_ROOT_PASSWORD environment variable from the linked mysql container)
+-e WORDPRESS_DB_NAME=... (defaults to "wordpress")
+-e WORDPRESS_TABLE_PREFIX=... (defaults to "", only set this when you need to override the default table prefix in wp-config.php)
+-e WORDPRESS_AUTH_KEY=..., -e WORDPRESS_SECURE_AUTH_KEY=..., -e WORDPRESS_LOGGED_IN_KEY=..., -e WORDPRESS_NONCE_KEY=..., -e WORDPRESS_AUTH_SALT=..., -e WORDPRESS_SECURE_AUTH_SALT=..., -e WORDPRESS_LOGGED_IN_SALT=..., -e WORDPRESS_NONCE_SALT=... (default to unique random SHA1s)
+If the WORDPRESS_DB_NAME specified does not already exist on the given MySQL server, it will be created automatically upon startup of the wordpress container, provided that the WORDPRESS_DB_USER specified has the necessary permissions to create it.

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -4,9 +4,14 @@
 The following environment variables are also honored for configuring your WordPress instance:
 
 -e WORDPRESS_DB_HOST=... (defaults to the IP and port of the linked mysql container)
+
 -e WORDPRESS_DB_USER=... (defaults to "root")
+
 -e WORDPRESS_DB_PASSWORD=... (defaults to the value of the MYSQL_ROOT_PASSWORD environment variable from the linked mysql container)
+
 -e WORDPRESS_DB_NAME=... (defaults to "wordpress")
+
 -e WORDPRESS_TABLE_PREFIX=... (defaults to "", only set this when you need to override the default table prefix in wp-config.php)
+
 -e WORDPRESS_AUTH_KEY=..., -e WORDPRESS_SECURE_AUTH_KEY=..., -e WORDPRESS_LOGGED_IN_KEY=..., -e WORDPRESS_NONCE_KEY=..., -e WORDPRESS_AUTH_SALT=..., -e WORDPRESS_SECURE_AUTH_SALT=..., -e WORDPRESS_LOGGED_IN_SALT=..., -e WORDPRESS_NONCE_SALT=... (default to unique random SHA1s)
 If the WORDPRESS_DB_NAME specified does not already exist on the given MySQL server, it will be created automatically upon startup of the wordpress container, provided that the WORDPRESS_DB_USER specified has the necessary permissions to create it.


### PR DESCRIPTION
Official WordPress 4.7 container, bundled with Apache 2.4.10 and PHP 7.1, needs external MySQL.