### PR TITLE
Update CloneDeploy Version

### DIFF
--- a/clonedeploy/Dockerfile
+++ b/clonedeploy/Dockerfile
@@ -1,6 +1,6 @@
 FROM clonedeploy/clonedeploy:latest
 LABEL org.freenas.interactive="false" \
-      org.freenas.version="1" \
+      org.freenas.version="1.2.1.0002" \
       org.freenas.upgradeable="false" \
       org.freenas.expose-ports-at-host="false" \
       org.freenas.autostart="false" \


### PR DESCRIPTION
Fixes a permission issue with the images location when a FreeNAS dataset
is used, due to setgid not translating to the dataset properly.