### PR TITLE
adding elk container

### DIFF
--- a/elk/Dockerfile
+++ b/elk/Dockerfile
@@ -1,0 +1,80 @@
+FROM sebp/elk:latest
+LABEL org.freenas.interactive="false" \
+      org.freenas.version="1" \
+      org.freenas.upgradeable="false" \
+      org.freenas.expose-ports-at-host="true" \
+      org.freenas.autostart="true" \
+      org.freenas.web-ui-protocol="http" \
+      org.freenas.web-ui-port="5601" \
+      org.freenas.web-ui-path="" \
+      org.freenas.port-mappings="5601:5601/tcp,9200:9200/tcp,5044:5044/tcp" \
+      org.freenas.volumes="[                          \
+          {                                           \
+              \"name\": \"/var/lib/elasticsearch\",   \
+              \"descr\": \"ES data\"                  \
+          },                                          \
+          {                                           \
+              \"name\": \"/etc/elasticsearch\",       \
+              \"descr\": \"ES config\"                \
+          },                                          \
+          {                                           \
+              \"name\": \"/etc/logstash/conf.d\",     \
+              \"descr\": \"logstash config\"          \
+          },                                          \
+          {                                           \
+              \"name\": \"/opt/kibana/config\",       \
+              \"descr\": \"kibana config\"            \
+          }                                           \
+      ]" \
+      org.freenas.settings="[                                                                                                            \
+          {                                                                                                                              \
+              \"env\": \"TZ\",                                                                                                           \
+              \"descr\": \"Timezone information, eg Europe/London. Default Etc/UTC\",                                                    \
+              \"optional\": true                                                                                                         \
+          },                                                                                                                             \
+          {                                                                                                                              \
+              \"env\": \"PGID\",                                                                                                         \
+              \"descr\": \"GroupID\",                                                                                                    \
+              \"optional\": true                                                                                                         \
+          },                                                                                                                             \
+          {                                                                                                                              \
+              \"env\": \"PUID\",                                                                                                         \
+              \"descr\": \"UserID\",                                                                                                     \
+              \"optional\": true                                                                                                         \
+          },                                                                                                                             \
+          {                                                                                                                              \
+              \"env\": \"ES_HEAP_SIZE\",                                                                                                 \
+              \"descr\": \"Elasticsearch heap size (default is 256MB min, 1G max)\",                                                     \
+              \"optional\": true                                                                                                         \
+          },                                                                                                                             \
+          {                                                                                                                              \
+              \"env\": \"ES_JAVA_OPTS\",                                                                                                 \
+              \"descr\": \"additional Java options for Elasticsearch\",                                                                  \
+              \"optional\": true                                                                                                         \
+          },                                                                                                                             \
+          {                                                                                                                              \
+              \"env\": \"ES_CONNECT_RETRY\",                                                                                             \
+              \"descr\": \"number of seconds to wait for Elasticsearch to be up before starting Logstash and/or Kibana (default: 30)\",  \
+              \"optional\": true                                                                                                         \
+          },                                                                                                                             \
+          {                                                                                                                              \
+              \"env\": \"CLUSTER_NAME\",                                                                                                 \
+              \"descr\": \"the name of the Elasticsearch cluster (default: automatically resolved when the container starts if Elasticsearch requires no user authentication)\",          \
+              \"optional\": true                                                                                                         \
+          },                                                                                                                             \
+          {                                                                                                                              \
+              \"env\": \"LS_HEAP_SIZE\",                                                                                                 \
+              \"descr\": \"Logstash heap size (default: 500m)\",                                                                         \
+              \"optional\": true                                                                                                         \
+          },                                                                                                                             \
+          {                                                                                                                              \
+              \"env\": \"LS_OPTS\",                                                                                                      \
+              \"descr\": \"Logstash options\",                                                                                           \
+              \"optional\": true                                                                                                         \
+          },                                                                                                                             \
+          {                                                                                                                              \
+              \"env\": \"NODE_OPTIONS\",                                                                                                 \
+              \"descr\": \"Node options for Kibana (default: --max-old-space-size=250)\",                                                \
+              \"optional\": true                                                                                                         \
+          }                                                                                                                              \
+      ]"

--- a/elk/Dockerfile
+++ b/elk/Dockerfile
@@ -14,16 +14,8 @@ LABEL org.freenas.interactive="false" \
               \"descr\": \"ES data\"                  \
           },                                          \
           {                                           \
-              \"name\": \"/etc/elasticsearch\",       \
-              \"descr\": \"ES config\"                \
-          },                                          \
-          {                                           \
               \"name\": \"/etc/logstash/conf.d\",     \
               \"descr\": \"logstash config\"          \
-          },                                          \
-          {                                           \
-              \"name\": \"/opt/kibana/config\",       \
-              \"descr\": \"kibana config\"            \
           }                                           \
       ]" \
       org.freenas.settings="[                                                                                                            \

--- a/elk/README.md
+++ b/elk/README.md
@@ -1,0 +1,24 @@
+# elkx-docker
+Elasticsearch, Logstash, Kibana (ELK) with X-Pack Docker image, based on the Docker image of [Sébastien Pujadas](https://github.com/spujadas/elkx-docker).
+
+## Parameters
+
+- **/var/lib/elasticsearch** Elasticsearch data.
+- **/etc/elasticsearch** Elasticsearch config folder.
+- **/etc/logstash/conf.d** Logstash config folder.
+- **/opt/kibana/config** Kibana config folder.
+
+# Important
+As explained in https://github.com/spujadas/elk-docker/issues/92#issuecomment-263152557 please make sure the VM running this container is configured correctly.
+
+{code:bash}
+# open a console into the VM that will be running the elk docker container
+sudo vi /var/lib/boot2docker/bootlocal.sh
+# Add this line into /var/lib/boot2docker/bootlocal.sh
+sysctl -w vm.max_map_count=262144
+sudo chmod +x /var/lib/boot2docker/bootlocal.sh
+{code}
+
+For some reason /var/lib/boot2docker is not being preserved after reboot. Further research needed.
+
+NOTE: https://github.com/docker/machine/issues/3859

--- a/elk/README.md
+++ b/elk/README.md
@@ -4,9 +4,7 @@ Elasticsearch, Logstash, Kibana (ELK) with X-Pack Docker image, based on the Doc
 ## Parameters
 
 - **/var/lib/elasticsearch** Elasticsearch data.
-- **/etc/elasticsearch** Elasticsearch config folder.
 - **/etc/logstash/conf.d** Logstash config folder.
-- **/opt/kibana/config** Kibana config folder.
 
 # Important
 As explained in https://github.com/spujadas/elk-docker/issues/92#issuecomment-263152557 please make sure the VM running this container is configured correctly.


### PR DESCRIPTION
I added the elk container from [sebp/elk](https://hub.docker.com/r/sebp/elk/) Docker image, which provides a convenient centralised log server and log management web interface, by packaging [Elasticsearch](https://www.elastic.co/), [Logstash](https://www.elastic.co/products/logstash), and [Kibana](https://www.elastic.co/products/kibana), collectively known as ELK.

More info https://elk-docker.readthedocs.io