### PR TITLE
nginx: Update default HTML path

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.freenas.interactive="false"                                         \
       org.freenas.port-mappings="80:8080/tcp,443:8081/tcp"                    \
       org.freenas.volumes="[						                  \
           {								                        \
-              \"name\": \"/var/www/html\",					      \
+              \"name\": \"/usr/share/nginx/html\",				      \
               \"descr\": \"html content\"		                              \
           },                                                                  \
           {								                        \


### PR DESCRIPTION
Change HTML path to match the one configured in the default nginx configuration in the base Dockerfile.  See https://hub.docker.com/_/nginx/ under the heading "hosting some simple static content".