### PR TITLE
Add MySQL support to seafile

### DIFF
--- a/seafile/Dockerfile
+++ b/seafile/Dockerfile
@@ -26,5 +26,5 @@ LABEL org.freenas.interactive="true"				\
       ]"
 
 USER root
-RUN sudo apk add --update py-mysqldb
+RUN apk add --update py-mysqldb
 USER seafile

--- a/seafile/Dockerfile
+++ b/seafile/Dockerfile
@@ -25,4 +25,4 @@ LABEL org.freenas.interactive="true"				\
           }                                           \
       ]"
 
-RUN apk add --update py-mysqldb
+RUN sudo apk add --update py-mysqldb

--- a/seafile/Dockerfile
+++ b/seafile/Dockerfile
@@ -12,3 +12,17 @@ LABEL org.freenas.interactive="true"				\
               \"descr\": \"Internal Path\"			\
           }							\
       ]"
+      org.freenas.settings="[ 					\
+          {							\
+              \"env\": \"SEAHUB\",					\
+              \"descr\": \"Set to fastcgi if desired otherwise empty\",		\
+              \"optional\": true				\
+          },							\
+          {							\
+              \"env\": \"SEAFILE_FASTCGI_HOST\",			\
+              \"descr\": \"Binding ip for seahub in FastCGI mode. Default: 127.0.0.1.\",	\
+              \"optional\": true				\
+          }
+      ]"
+
+RUN apk add --update py-mysqldb

--- a/seafile/Dockerfile
+++ b/seafile/Dockerfile
@@ -25,4 +25,6 @@ LABEL org.freenas.interactive="true"				\
           }                                           \
       ]"
 
+USER root
 RUN sudo apk add --update py-mysqldb
+USER seafile

--- a/seafile/Dockerfile
+++ b/seafile/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.freenas.interactive="true"				\
               \"name\": \"/home/seafile\",			\
               \"descr\": \"Internal Path\"			\
           }							\
-      ]"
+      ]"                                        \
       org.freenas.settings="[ 					\
           {							\
               \"env\": \"SEAHUB\",					\
@@ -22,7 +22,7 @@ LABEL org.freenas.interactive="true"				\
               \"env\": \"SEAFILE_FASTCGI_HOST\",			\
               \"descr\": \"Binding ip for seahub in FastCGI mode. Default: 127.0.0.1.\",	\
               \"optional\": true				\
-          }
+          }                                           \
       ]"
 
 RUN apk add --update py-mysqldb


### PR DESCRIPTION
Existing seafile image missing the python mysql libraries so is unable to boot with mysql backend.

Added mysql libraries and some environment variables for fastcgi (required to sit behind nginx).