### PR TITLE
Added standard PUID/PGID settings to sickrage Dockerfile

### DIFF
--- a/sickrage/Dockerfile
+++ b/sickrage/Dockerfile
@@ -27,6 +27,16 @@ LABEL org.freenas.interactive="false" \
               \"env\": \"TZ\",						\
               \"descr\": \"Timezone information, eg Europe/London\",	\
               \"optional\": true					\
+          },								\
+          {								\
+              \"env\": \"PUID\",					\
+              \"descr\": \"User ID\",					\
+              \"optional\": true					\
+          },								\
+          {								\
+              \"env\": \"PGID\",					\
+              \"descr\": \"Group ID\",					\
+              \"optional\": true					\
           }								\
       ]"
 


### PR DESCRIPTION
The sickrage container supports these ENV vars but they were missing from the Dockerfile.