### PR TITLE
Updated mandatory variables after recent mono switch

### DIFF
--- a/sonarr/Dockerfile
+++ b/sonarr/Dockerfile
@@ -24,6 +24,11 @@ LABEL org.freenas.interactive="false" \
       ]" \
        org.freenas.settings="[ 						                        \
           {								                                    \
+              \"env\": \"TZ\",					                              \
+              \"descr\": \"Europe/London\",				\
+              \"optional\": false					                              \
+          },
+          {								                                    \
               \"env\": \"PUID\",					                              \
               \"descr\": \"SONARR USER ID\",				\
               \"optional\": true					                              \


### PR DESCRIPTION
No longer works after switching to mono.
Added TZ as mandatory to fix the issue.
https://github.com/linuxserver/docker-sonarr/commits/master