### PR TITLE
Add wekan image

### DIFF
--- a/wekan/Dockerfile
+++ b/wekan/Dockerfile
@@ -1,0 +1,21 @@
+FROM wekanteam/wekan:meteor-1.4
+LABEL org.freenas.interactive="false"\
+      org.freenas.version="1.4"\
+      org.freenas.upgradeable="false"\
+      org.freenas.expose-ports-at-host="true"\
+      org.freenas.autostart="true"\
+      org.freenas.web-ui-protocol="http"\
+      org.freenas.web-ui-port=8280\
+      org.freenas.port-mappings="8280:80/tcp"\
+      org.freenas.settings="[\
+          {\
+              \"env\": \"MONGO_URL\",\
+              \"descr\": \"mongodb://myMongoDbIPorFQDN\",\
+              \"optional\": false\
+          },\
+          {\
+              \"env\": \"ROOT_URL\",\
+              \"descr\": \"URL that this container will be accessed on, including port\",\
+              \"optional\": false\
+          }\
+      ]"

--- a/wekan/README.md
+++ b/wekan/README.md
@@ -1,0 +1,5 @@
+# Freenas Wekan Image
+
+This image requires MongoDB for storage.
+
+For more info please see the [Official Wekan Docker Instructions](https://github.com/wekan/wekan/wiki/Docker).


### PR DESCRIPTION
This is a simple wrapper around the [official wekan image](https://hub.docker.com/r/wekanteam/wekan), it requires a MongoDB which is already wrapped in the freenas/docker-images repo.