### PR TITLE
the public tag is not updated, use latest instead

### DIFF
--- a/plex/Dockerfile
+++ b/plex/Dockerfile
@@ -1,4 +1,4 @@
-FROM plexinc/pms-docker:public
+FROM plexinc/pms-docker:latest
 LABEL org.freenas.interactive="false" 		\
       org.freenas.version="Latest (Auto Update)"		\
       org.freenas.upgradeable="true"		\


### PR DESCRIPTION
reference: https://hub.docker.com/r/plexinc/pms-docker/tags/